### PR TITLE
Set up CI/CD pipeline for Docker Hub releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,78 @@
+name: Build and Push Docker Image on Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  DOCKER_IMAGE: jonsilver/music-assistant-ai-playlist-creator
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract version from release tag
+        id: get_version
+        run: |
+          # Get the tag name from the release (e.g., v1.2.3)
+          VERSION=${GITHUB_REF#refs/tags/}
+          # Remove 'v' prefix if present
+          VERSION=${VERSION#v}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Release version: ${VERSION}"
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tags: |
+            # Tag with the exact version number (e.g., 1.2.3)
+            type=semver,pattern={{version}}
+            # Tag with major.minor (e.g., 1.2)
+            type=semver,pattern={{major}}.{{minor}}
+            # Tag with major version (e.g., 1)
+            type=semver,pattern={{major}}
+            # Also tag as latest
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ env.DOCKER_IMAGE }}
+          short-description: ${{ github.event.repository.description }}
+          readme-filepath: ./README.md
+
+      - name: Image digest
+        run: |
+          echo "✅ Docker image published successfully!"
+          echo "Version: ${{ steps.get_version.outputs.version }}"
+          echo "Tags: ${{ steps.meta.outputs.tags }}"
+          echo "Digest: ${{ steps.build-and-push.outputs.digest }}"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -17,12 +17,27 @@ This guide covers the CI/CD pipeline and deployment options for the Music Assist
 
 The project uses GitHub Actions to automatically build and push Docker images to Docker Hub. Images are built for both `linux/amd64` and `linux/arm64` platforms.
 
+### Initial Docker Hub Setup
+
+If this is your first time setting up the repository:
+
+1. **Create Docker Hub Repository:**
+   - Log in to [Docker Hub](https://hub.docker.com/)
+   - Click "Create Repository"
+   - Name: `music-assistant-ai-playlist-creator`
+   - Visibility: Public (or Private if you prefer)
+   - Click "Create"
+
+   Your repository will be at: `jonsilver/music-assistant-ai-playlist-creator`
+
+2. **The README will be automatically synced:**
+   - When you publish your first release, the GitHub Actions workflow will automatically update the Docker Hub repository description with your README.md content
+   - This keeps the Docker Hub documentation in sync with your GitHub repository
+
 ### Triggers
 
 The pipeline runs automatically on:
-- **Push to `main` branch**: Builds and tags as `latest`
-- **Version tags** (e.g., `v1.2.3`): Builds and tags with semantic version
-- **Manual trigger**: Via GitHub Actions workflow dispatch
+- **GitHub Releases**: When you publish a new release on GitHub, the pipeline automatically builds and pushes Docker images
 
 ### Setup GitHub Secrets
 
@@ -46,12 +61,16 @@ To enable the CI/CD pipeline, configure these secrets in your GitHub repository:
 
 ### Image Tagging Strategy
 
-The pipeline automatically creates the following tags:
+When you publish a release on GitHub, the pipeline automatically creates the following Docker image tags:
 
-| Condition | Tags Created | Example |
-|-----------|--------------|---------|
-| Push to `main` | `latest`, `main-<sha>` | `latest`, `main-a1b2c3d` |
-| Version tag | `<version>`, `<major>.<minor>`, `<major>` | `1.2.3`, `1.2`, `1` |
+| Tag Type | Format | Example |
+|----------|--------|---------|
+| Full version | `<version>` | `1.2.3` |
+| Major.Minor | `<major>.<minor>` | `1.2` |
+| Major only | `<major>` | `1` |
+| Latest | `latest` | `latest` |
+
+**Example:** Publishing release `v1.2.3` creates tags: `1.2.3`, `1.2`, `1`, and `latest`
 
 ### Customizing the Docker Image Name
 
@@ -218,29 +237,37 @@ The development compose file (`docker-compose.dev.yml`) builds the Docker image 
 
 ### Creating a Release
 
+Follow these steps to create a new release and trigger the CI/CD pipeline:
+
 1. **Update version in package.json:**
    ```bash
    # This happens automatically with build:prod
    npm run build:prod
    ```
 
-2. **Commit changes:**
+2. **Commit and push changes:**
    ```bash
    git add .
    git commit -m "chore: version bump to X.Y.Z"
+   git push origin main
    ```
 
-3. **Create and push version tag:**
-   ```bash
-   git tag v1.2.3
-   git push origin main
-   git push origin v1.2.3
-   ```
+3. **Create a GitHub Release:**
+   - Go to your repository on GitHub
+   - Click on "Releases" → "Create a new release"
+   - Click "Choose a tag" and create a new tag (e.g., `v1.2.3`)
+   - Fill in the release title (e.g., `v1.2.3` or `Version 1.2.3`)
+   - Add release notes describing the changes
+   - Click "Publish release"
 
 4. **GitHub Actions automatically:**
-   - Builds the Docker image
+   - Detects the new release
+   - Builds the Docker image for `linux/amd64` and `linux/arm64`
    - Tags it with `1.2.3`, `1.2`, `1`, and `latest`
-   - Pushes to Docker Hub
+   - Pushes all tags to Docker Hub
+   - Updates the Docker Hub repository description with the README
+
+**Note:** The pipeline only triggers when you **publish** a release on GitHub, not when you push tags directly.
 
 ### Versioning Strategy
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ An AI-powered web application for creating intelligent playlists in Music Assist
 
 ### Production Deployment (from Docker Hub)
 
-For production deployment on a server, pre-built images are available on Docker Hub:
+Pre-built Docker images are automatically published to Docker Hub when new releases are created on GitHub.
+
+**Docker Hub Repository:** [`jonsilver/music-assistant-ai-playlist-creator`](https://hub.docker.com/r/jonsilver/music-assistant-ai-playlist-creator)
 
 ```bash
-# Quick start
+# Quick start - deploy latest version
 curl -O https://raw.githubusercontent.com/JonSilver/music-assistant-ai-playlist-creator/main/docker-compose.yml
 curl -O https://raw.githubusercontent.com/JonSilver/music-assistant-ai-playlist-creator/main/.env.production.example
 mv .env.production.example .env
@@ -67,7 +69,7 @@ docker-compose pull
 docker-compose up -d
 ```
 
-**See [DEPLOYMENT.md](./DEPLOYMENT.md) for complete deployment guide including CI/CD setup.**
+**See [DEPLOYMENT.md](./DEPLOYMENT.md) for complete deployment guide, version management, and CI/CD setup.**
 
 ### Local Development with Docker
 
@@ -436,7 +438,7 @@ To use a different location, edit `DATA_PATH` in your `.env` file.
 │
 ├── .github/
 │   └── workflows/
-│       └── docker-publish.yml   # CI/CD pipeline for Docker Hub
+│       └── docker-publish.yml   # CI/CD pipeline (triggers on GitHub releases)
 │
 ├── Dockerfile                   # Production container build
 ├── docker-compose.yml           # Production deployment (Docker Hub)
@@ -518,9 +520,21 @@ Configure an ordered list of provider keywords (e.g., "spotify", "tidal", "local
 ## Updating
 
 ### Production Deployment
+
+To update to the latest version from Docker Hub:
 ```bash
 docker-compose pull    # Pull latest image from Docker Hub
 docker-compose up -d   # Restart with new image
+```
+
+To deploy a specific version, edit your `.env` file:
+```env
+IMAGE_TAG=1.2.3  # Specify exact version
+```
+
+Then pull and restart:
+```bash
+docker-compose pull && docker-compose up -d
 ```
 
 ### Local Development
@@ -529,7 +543,15 @@ docker-compose -f docker-compose.dev.yml down
 docker-compose -f docker-compose.dev.yml up --build
 ```
 
-See [DEPLOYMENT.md](./DEPLOYMENT.md) for version management and release procedures.
+### Creating New Releases
+
+New Docker images are automatically built and published when you create a GitHub release:
+1. Update version with `npm run build:prod`
+2. Commit and push to main
+3. Create a new release on GitHub with a version tag (e.g., `v1.2.3`)
+4. GitHub Actions builds and pushes to Docker Hub automatically
+
+See [DEPLOYMENT.md](./DEPLOYMENT.md) for detailed version management and CI/CD procedures.
 
 ## Troubleshooting
 


### PR DESCRIPTION
- Update GitHub Actions workflow to trigger only on published releases
- Add automatic README sync to Docker Hub repository description
- Update DEPLOYMENT.md with release-based workflow instructions
- Add Docker Hub initial setup guide
- Clarify production deployment process in README
- Images are tagged with version, major.minor, major, and latest
- Multi-platform builds for linux/amd64 and linux/arm64