### PR TITLE
feat: add PWA manifest for mobile home screen support

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,8 +4,19 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Playlist Creator for Music Assistant</title>
+
+  <!-- PWA Manifest -->
+  <link rel="manifest" href="/manifest.json" />
+
+  <!-- PWA Meta Tags -->
+  <meta name="theme-color" content="#6366f1" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="Playlist Creator" />
+  <link rel="apple-touch-icon" href="/logo.png" />
 </head>
 
 <body>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "Playlist Creator for Music Assistant",
+  "short_name": "Playlist Creator",
+  "description": "Create AI-powered playlists for Music Assistant",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#1a1a2e",
+  "theme_color": "#6366f1",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/favicon.ico",
+      "sizes": "32x32 48x48 64x64",
+      "type": "image/x-icon"
+    }
+  ]
+}


### PR DESCRIPTION
Add manifest.json with app metadata, icons, and standalone display mode.
Update index.html with PWA meta tags for iOS and Android compatibility.

Fixes #13