### PR TITLE
Fixes #7: allow for mandatory authentication for Music Assistant 2.7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ docker-compose up -d
 
 5. Go to Settings and configure:
    - Music Assistant URL (e.g., `http://192.168.1.100:8095`)
+   - Music Assistant Token (required for MA 2.7+ - see "Authentication" section below)
    - Add one or more AI providers (Claude, OpenAI, or compatible endpoints)
    - For each provider: name, API key, model selection, optional base URL and temperature
    - Optionally configure provider weights (prioritise specific music sources like Spotify, Tidal, etc.)
@@ -293,7 +294,8 @@ POST /api/playlists/test-ma
 Content-Type: application/json
 
 {
-  "musicAssistantUrl": "http://192.168.1.100:8095"
+  "musicAssistantUrl": "http://192.168.1.100:8095",
+  "musicAssistantToken": "your-ma-token"  // Required for MA 2.7+
 }
 
 Response: {
@@ -454,6 +456,7 @@ When providing a `webhookUrl` in the generation request:
 All application settings are configured through the web interface and stored in SQLite:
 
 - **Music Assistant URL**: WebSocket endpoint for your Music Assistant instance
+- **Music Assistant Token**: Authentication token for MA 2.7+ (see "Authentication" section)
 - **AI Providers**: Add multiple providers with individual configuration:
   - Name (e.g., "Claude Sonnet", "OpenAI GPT-4")
   - Type (Anthropic or OpenAI-compatible)
@@ -552,7 +555,15 @@ The backend connects to Music Assistant via WebSocket to:
 
 All Music Assistant operations are performed server-side with results streamed to connected clients in real-time.
 
-**Note**: No authentication is required as Music Assistant is designed for local network use.
+### Authentication (MA 2.7+)
+
+Music Assistant 2.7 introduced mandatory authentication. To configure:
+
+1. Log into your Music Assistant web interface
+2. Open browser DevTools (F12) → Application tab → Local Storage
+3. Copy the value of `ma_access_token`
+4. Paste into the "Music Assistant Token" field in Settings
+5. Click "Test Connection" to verify authentication works
 
 ## AI Integration
 

--- a/backend/src/services/musicAssistantTypes.ts
+++ b/backend/src/services/musicAssistantTypes.ts
@@ -1,0 +1,43 @@
+/**
+ * Music Assistant client types - extracted to keep main file under 200 lines
+ */
+
+import type { MATrack } from "../../../shared/types.js";
+
+export interface MAResponse {
+    message_id?: string;
+    result?: unknown;
+    error?: {
+        error_code: string;
+        message: string;
+    };
+}
+
+export interface MASearchResults {
+    artists: unknown[];
+    albums: unknown[];
+    tracks: MATrack[];
+    playlists: unknown[];
+    radio: unknown[];
+    podcasts?: unknown[];
+    audiobooks?: unknown[];
+}
+
+export interface MAFavoritesResponse {
+    count: number;
+    total: number;
+    items: { name: string }[];
+}
+
+export interface MAPlaylist {
+    item_id: string;
+    provider: string;
+    name: string;
+    uri: string;
+}
+
+export interface PendingRequest {
+    resolve: (value: unknown) => void;
+    reject: (error: Error) => void;
+    timeout: NodeJS.Timeout;
+}

--- a/backend/src/services/playlistCreator.ts
+++ b/backend/src/services/playlistCreator.ts
@@ -4,9 +4,10 @@ import { withMusicAssistant } from "../utils/maClientUtils.js";
 export const createPlaylist = async (
     playlistName: string,
     tracks: TrackMatch[],
-    musicAssistantUrl: string
+    musicAssistantUrl: string,
+    musicAssistantToken?: string
 ): Promise<{ playlistId: string; tracksAdded: number; playlistUrl: string }> =>
-    withMusicAssistant(musicAssistantUrl, async maClient => {
+    withMusicAssistant(musicAssistantUrl, musicAssistantToken, async maClient => {
         const playlistId = await maClient.createPlaylist(playlistName.trim());
 
         const trackUris = tracks

--- a/backend/src/services/playlistGenerator.ts
+++ b/backend/src/services/playlistGenerator.ts
@@ -13,6 +13,7 @@ interface GeneratePlaylistParams {
     jobId: string;
     prompt: string;
     musicAssistantUrl: string;
+    musicAssistantToken?: string;
     providerConfig: AIProviderConfig;
     customSystemPrompt?: string;
     providerKeywords?: string[];
@@ -28,6 +29,7 @@ export const generatePlaylistJob = async (
         jobId,
         prompt,
         musicAssistantUrl,
+        musicAssistantToken,
         providerConfig,
         customSystemPrompt,
         providerKeywords = [],
@@ -42,7 +44,7 @@ export const generatePlaylistJob = async (
 
         // Get favorite artists
         const maClient = new MusicAssistantClient(musicAssistantUrl);
-        await maClient.connect();
+        await maClient.connect(musicAssistantToken);
         const favoriteArtists = await maClient.getFavoriteArtists();
         maClient.disconnect();
 
@@ -72,7 +74,7 @@ export const generatePlaylistJob = async (
 
         // Step 2: Match tracks progressively
         const maClientForMatching = new MusicAssistantClient(musicAssistantUrl);
-        await maClientForMatching.connect();
+        await maClientForMatching.connect(musicAssistantToken);
 
         const tracks = [...initialTracks];
 
@@ -101,7 +103,7 @@ export const generatePlaylistJob = async (
             const playlistName = prompt.length > 50 ? prompt.substring(0, 47) + "..." : prompt;
 
             const [createErr, result] = await attemptPromise(async () =>
-                createPlaylist(playlistName, tracks, musicAssistantUrl)
+                createPlaylist(playlistName, tracks, musicAssistantUrl, musicAssistantToken)
             );
 
             if (createErr !== undefined) 

--- a/backend/src/services/playlistRefine.ts
+++ b/backend/src/services/playlistRefine.ts
@@ -9,11 +9,12 @@ export const refinePlaylist = async (
     refinementPrompt: string,
     currentTracks: TrackMatch[],
     musicAssistantUrl: string,
+    musicAssistantToken: string | undefined,
     providerConfig: AIProviderConfig,
     customSystemPrompt?: string
 ): Promise<TrackMatch[]> => {
     const maClient = new MusicAssistantClient(musicAssistantUrl);
-    await maClient.connect();
+    await maClient.connect(musicAssistantToken);
 
     const [favoriteErr, favoriteArtists] = await attemptPromise(async () =>
         maClient.getFavoriteArtists()
@@ -74,11 +75,12 @@ export const replaceTrack = async (
     originalPrompt: string,
     playlistName: string,
     musicAssistantUrl: string,
+    musicAssistantToken: string | undefined,
     providerConfig: AIProviderConfig,
     customSystemPrompt?: string
 ): Promise<TrackMatch> => {
     const maClient = new MusicAssistantClient(musicAssistantUrl);
-    await maClient.connect();
+    await maClient.connect(musicAssistantToken);
 
     const [favoriteErr, favoriteArtists] = await attemptPromise(async () =>
         maClient.getFavoriteArtists()

--- a/backend/src/utils/maClientUtils.ts
+++ b/backend/src/utils/maClientUtils.ts
@@ -2,10 +2,11 @@ import { MusicAssistantClient } from "../services/musicAssistant.js";
 
 export const withMusicAssistant = async <T>(
     url: string,
+    token: string | undefined,
     operation: (client: MusicAssistantClient) => Promise<T>
 ): Promise<T> => {
     const client = new MusicAssistantClient(url);
-    await client.connect();
+    await client.connect(token);
     // eslint-disable-next-line no-restricted-syntax
     try {
         return await operation(client);

--- a/docs/issue-7-ma-auth-fix-plan.md
+++ b/docs/issue-7-ma-auth-fix-plan.md
@@ -1,0 +1,94 @@
+# Fix Music Assistant Authentication (Issue #7)
+
+## Problem
+Music Assistant 2.7 made authentication mandatory. The WebSocket connects fine but subsequent commands fail without sending an auth token first. The current "Test Connection" button only tests WebSocket connectivity, not authentication.
+
+## Authentication Flow (from MA frontend code)
+1. WebSocket connects → server sends `ServerInfoMessage`
+2. Client sends `auth` command with `{ token: "<access_token>", device_name: "<name>" }`
+3. Server responds with success → client is authenticated
+4. Subsequent commands work
+
+Token is obtained from MA web UI:
+1. Log into Music Assistant web interface
+2. Open browser dev tools (F12) → Application tab → Local Storage
+3. Find key `ma_access_token` and copy its value
+
+## Implementation Plan
+
+### 1. Add `musicAssistantToken` setting
+
+**File: `shared/settings-schema.ts`**
+- Add new setting field:
+```typescript
+musicAssistantToken: {
+  key: 'musicAssistantToken',
+  type: 'string',
+  optional: true,
+  zodSchema: z.string().optional()
+}
+```
+- Update `AppSettingsSchema` and `UpdateSettingsRequestSchema`
+- Update `getSettings` return type
+
+### 2. Update MusicAssistantClient to authenticate
+
+**File: `backend/src/services/musicAssistant.ts`**
+- Modify `connect()` to accept optional token parameter
+- After WebSocket opens, if token provided, send `auth` command:
+```typescript
+await this.sendCommand('auth', {
+  token,
+  device_name: 'music-assistant-ai-playlist-creator'
+});
+```
+- Only proceed once auth succeeds
+
+### 3. Update all client usages to pass token
+
+**Files:**
+- `backend/src/utils/maClientUtils.ts` - `withMusicAssistant(url, token, operation)`
+- `backend/src/services/playlistGenerator.ts` - pass token to client
+- `backend/src/services/playlistRefine.ts` - pass token to client
+- `backend/src/services/playlistCreator.ts` - pass token to client
+- `backend/src/routes/playlists.ts` - pass token in test-ma endpoint
+
+### 4. Fix test connection endpoint
+
+**File: `backend/src/routes/playlists.ts`**
+- Change `/playlists/test-ma` to actually test authentication
+- Accept both `musicAssistantUrl` and `musicAssistantToken` in request body
+- Call a simple MA command (e.g., `getFavoriteArtists`) to verify auth works
+- Return specific error if auth fails vs connection fails
+
+### 5. Update frontend settings UI
+
+**File: `frontend/src/components/SettingsPage.tsx`**
+- Add token input field (type="password" for security)
+- Pass token to test connection API call
+- Show appropriate error messages for auth failures
+
+**File: `frontend/src/hooks/useSettings.ts`**
+- Add `musicAssistantToken` to state management
+
+**File: `frontend/src/services/playlistApi.ts`**
+- Update `testMusicAssistantConnection` to accept token
+
+### 6. Update README
+
+**File: `README.md`**
+- Document that MA 2.7+ requires authentication
+- Explain how to obtain token from MA web UI
+
+## Files to Modify
+1. `shared/settings-schema.ts` - add token setting
+2. `backend/src/services/musicAssistant.ts` - add auth flow
+3. `backend/src/utils/maClientUtils.ts` - pass token
+4. `backend/src/services/playlistGenerator.ts` - pass token
+5. `backend/src/services/playlistRefine.ts` - pass token
+6. `backend/src/services/playlistCreator.ts` - pass token
+7. `backend/src/routes/playlists.ts` - fix test endpoint
+8. `frontend/src/components/SettingsPage.tsx` - token UI
+9. `frontend/src/hooks/useSettings.ts` - token state
+10. `frontend/src/services/playlistApi.ts` - token in API
+11. `README.md` - documentation

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -12,6 +12,8 @@ import { VersionCopyrightFooter } from "./VersionCopyrightFooter";
 interface ISettingsPageProps {
     musicAssistantUrl: string;
     setMusicAssistantUrl: (value: string) => void;
+    musicAssistantToken: string;
+    setMusicAssistantToken: (value: string) => void;
     aiProviders: AIProviderConfig[];
     setAiProviders: (value: AIProviderConfig[]) => void;
     customSystemPrompt: string;
@@ -33,6 +35,8 @@ interface ISettingsPageProps {
 export const SettingsPage: React.FC<ISettingsPageProps> = ({
     musicAssistantUrl,
     setMusicAssistantUrl,
+    musicAssistantToken,
+    setMusicAssistantToken,
     aiProviders,
     setAiProviders,
     customSystemPrompt,
@@ -102,6 +106,27 @@ export const SettingsPage: React.FC<ISettingsPageProps> = ({
                                         : `Connection failed: ${testResults.ma.error ?? "Unknown error"}`}
                                 </div>
                             )}
+                        </div>
+
+                        <div className="form-control mb-4">
+                            <label className="label">
+                                <span className="label-text">Music Assistant Token</span>
+                            </label>
+                            <input
+                                type="password"
+                                placeholder="Paste token from MA web UI"
+                                className="input input-bordered"
+                                value={musicAssistantToken}
+                                onChange={e => {
+                                    setMusicAssistantToken(e.target.value);
+                                }}
+                            />
+                            <label className="label">
+                                <span className="label-text-alt">
+                                    Required for MA 2.7+. Get from browser DevTools → Application →
+                                    Local Storage → ma_access_token
+                                </span>
+                            </label>
                         </div>
 
                         <div className="divider"></div>

--- a/frontend/src/components/SettingsView.tsx
+++ b/frontend/src/components/SettingsView.tsx
@@ -8,6 +8,7 @@ interface ISettingsViewProps {
     settings: GetSettingsResponse | null;
     updateSettings: (updates: {
         musicAssistantUrl: string;
+        musicAssistantToken?: string;
         aiProviders: AIProviderConfig[];
         customSystemPrompt?: string;
         providerWeights?: string;
@@ -44,6 +45,8 @@ export const SettingsView: React.FC<ISettingsViewProps> = ({
             <SettingsPage
                 musicAssistantUrl={settingsManager.musicAssistantUrl}
                 setMusicAssistantUrl={settingsManager.setMusicAssistantUrl}
+                musicAssistantToken={settingsManager.musicAssistantToken}
+                setMusicAssistantToken={settingsManager.setMusicAssistantToken}
                 aiProviders={settingsManager.aiProviders}
                 setAiProviders={settingsManager.setAiProviders}
                 customSystemPrompt={settingsManager.customSystemPrompt}

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -9,6 +9,8 @@ interface TestResults {
 interface UseSettingsReturn {
     musicAssistantUrl: string;
     setMusicAssistantUrl: (url: string) => void;
+    musicAssistantToken: string;
+    setMusicAssistantToken: (token: string) => void;
     aiProviders: AIProviderConfig[];
     setAiProviders: (providers: AIProviderConfig[]) => void;
     customSystemPrompt: string;
@@ -28,6 +30,7 @@ export const useSettings = (
     settings: GetSettingsResponse | null,
     updateSettings: (updates: {
         musicAssistantUrl: string;
+        musicAssistantToken?: string;
         aiProviders: AIProviderConfig[];
         customSystemPrompt?: string;
         providerWeights?: string;
@@ -37,6 +40,7 @@ export const useSettings = (
     closeSettings: () => void
 ): UseSettingsReturn => {
     const [musicAssistantUrl, setMusicAssistantUrl] = useState("");
+    const [musicAssistantToken, setMusicAssistantToken] = useState("");
     const [aiProviders, setAiProviders] = useState<AIProviderConfig[]>([]);
     const [customSystemPrompt, setCustomSystemPrompt] = useState("");
     const [providerWeights, setProviderWeights] = useState("[]");
@@ -47,6 +51,7 @@ export const useSettings = (
     useEffect(() => {
         if (settings !== null) {
             setMusicAssistantUrl(settings.musicAssistantUrl);
+            setMusicAssistantToken(settings.musicAssistantToken ?? "");
             setAiProviders(settings.aiProviders);
             setCustomSystemPrompt(settings.customSystemPrompt ?? "");
             setProviderWeights(settings.providerWeights);
@@ -58,7 +63,8 @@ export const useSettings = (
         setTestingMA(true);
         setTestResults({ ...testResults, ma: undefined });
 
-        const result = await testMusicAssistantConnection(musicAssistantUrl);
+        const token = musicAssistantToken.trim().length > 0 ? musicAssistantToken : undefined;
+        const result = await testMusicAssistantConnection(musicAssistantUrl, token);
         setTestResults({ ...testResults, ma: result });
 
         setTestingMA(false);
@@ -77,6 +83,8 @@ export const useSettings = (
 
         const err = await updateSettings({
             musicAssistantUrl,
+            musicAssistantToken:
+                musicAssistantToken.trim().length > 0 ? musicAssistantToken : undefined,
             aiProviders,
             customSystemPrompt:
                 customSystemPrompt.trim().length > 0 ? customSystemPrompt : undefined,
@@ -92,6 +100,7 @@ export const useSettings = (
         closeSettings();
     }, [
         musicAssistantUrl,
+        musicAssistantToken,
         aiProviders,
         customSystemPrompt,
         providerWeights,
@@ -104,6 +113,7 @@ export const useSettings = (
     const handleCancelSettings = useCallback((): void => {
         if (settings !== null) {
             setMusicAssistantUrl(settings.musicAssistantUrl);
+            setMusicAssistantToken(settings.musicAssistantToken ?? "");
             setAiProviders(settings.aiProviders);
             setCustomSystemPrompt(settings.customSystemPrompt ?? "");
             setProviderWeights(settings.providerWeights);
@@ -115,6 +125,8 @@ export const useSettings = (
     return {
         musicAssistantUrl,
         setMusicAssistantUrl,
+        musicAssistantToken,
+        setMusicAssistantToken,
         aiProviders,
         setAiProviders,
         customSystemPrompt,

--- a/frontend/src/services/playlistApi.ts
+++ b/frontend/src/services/playlistApi.ts
@@ -131,19 +131,19 @@ export const replaceTrackViaBackend = async (
 };
 
 export const testMusicAssistantConnection = async (
-    musicAssistantUrl: string
+    musicAssistantUrl: string,
+    musicAssistantToken?: string
 ): Promise<BackendTestMAResponse> => {
     const [err, result] = await attemptPromise(async () =>
         backendFetch<BackendTestMAResponse>(API_ENDPOINTS.PLAYLISTS_TEST_MA, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ musicAssistantUrl })
+            body: JSON.stringify({ musicAssistantUrl, musicAssistantToken })
         })
     );
 
-    if (err !== undefined) 
+    if (err !== undefined)
         return { success: false, error: err.message };
-    
 
     return result;
 };

--- a/shared/constants/music-assistant.ts
+++ b/shared/constants/music-assistant.ts
@@ -4,12 +4,16 @@
 
 // Music Assistant WebSocket commands
 export const MA_COMMANDS = {
+    AUTH: 'auth',
     SEARCH: 'music/search',
     FAVORITES: 'music/favorites',
     LIBRARY_ITEMS: 'music/library_items',
     CREATE_PLAYLIST: 'music/playlists/create_playlist',
     ADD_PLAYLIST_TRACKS: 'music/playlists/add_playlist_tracks'
 } as const;
+
+// Device name for authentication
+export const MA_DEVICE_NAME = 'music-assistant-ai-playlist-creator';
 
 // Media types
 export const MEDIA_TYPES = {

--- a/shared/settings-utils.ts
+++ b/shared/settings-utils.ts
@@ -1,0 +1,163 @@
+/**
+ * Utility functions for working with settings
+ * Extracted from settings-schema.ts to keep files under 200 lines
+ */
+
+import type { AIProviderConfig, SettingFieldType, SettingKey } from './settings-schema.js';
+import { SETTINGS_FIELDS } from './settings-schema.js';
+
+type SettingsFieldsConfig = typeof SETTINGS_FIELDS;
+
+type SettingField = SettingsFieldsConfig[SettingKey];
+
+type InferFieldValue<F extends SettingField> =
+  F extends { optional: true }
+    ? F extends { defaultValue: infer D }
+      ? D | undefined
+      : F extends { type: 'providers' }
+        ? AIProviderConfig[] | undefined
+        : string | undefined
+    : F extends { type: 'providers' }
+      ? AIProviderConfig[]
+      : string;
+
+/** @public */
+export const settingsUtils = {
+  getAllKeys: (): SettingKey[] => Object.keys(SETTINGS_FIELDS) as SettingKey[],
+
+  getField: <K extends SettingKey>(key: K): SettingsFieldsConfig[K] => SETTINGS_FIELDS[key],
+
+  getFieldType: (key: SettingKey): SettingFieldType => SETTINGS_FIELDS[key].type,
+
+  isOptional: (key: SettingKey): boolean => SETTINGS_FIELDS[key].optional ?? false,
+
+  serialiseForDB: <K extends SettingKey>(
+    key: K,
+    value: InferFieldValue<SettingsFieldsConfig[K]>
+  ): string => {
+    const field = SETTINGS_FIELDS[key];
+    if ('dbTransform' in field && field.dbTransform !== undefined) {
+      return field.dbTransform.serialise(value as never);
+    }
+    return String(value);
+  },
+
+  deserialiseFromDB: <K extends SettingKey>(
+    key: K,
+    value: string | null
+  ): InferFieldValue<SettingsFieldsConfig[K]> | undefined => {
+    const field = SETTINGS_FIELDS[key];
+    if (value === null) {
+      return ('defaultValue' in field ? field.defaultValue : undefined) as InferFieldValue<SettingsFieldsConfig[K]> | undefined;
+    }
+    if ('dbTransform' in field && field.dbTransform !== undefined) {
+      return field.dbTransform.deserialise(value) as InferFieldValue<SettingsFieldsConfig[K]> | undefined;
+    }
+    return value as InferFieldValue<SettingsFieldsConfig[K]>;
+  },
+
+  getDefaultValue: <K extends SettingKey>(
+    key: K
+  ): InferFieldValue<SettingsFieldsConfig[K]> | undefined => {
+    const field = SETTINGS_FIELDS[key];
+    return ('defaultValue' in field ? field.defaultValue : undefined) as InferFieldValue<SettingsFieldsConfig[K]> | undefined;
+  },
+
+  formValueToApiValue: <K extends SettingKey>(
+    key: K,
+    formValue: string
+  ): InferFieldValue<SettingsFieldsConfig[K]> | undefined => {
+    const field = SETTINGS_FIELDS[key];
+    if (formValue.length === 0 && field.optional) {
+      return undefined;
+    }
+    if (field.type === 'providers') {
+      try {
+        return JSON.parse(formValue) as InferFieldValue<SettingsFieldsConfig[K]>;
+      } catch {
+        return [] as InferFieldValue<SettingsFieldsConfig[K]>;
+      }
+    }
+    return formValue as InferFieldValue<SettingsFieldsConfig[K]>;
+  },
+
+  apiValueToFormValue: <K extends SettingKey>(
+    key: K,
+    apiValue: InferFieldValue<SettingsFieldsConfig[K]> | undefined
+  ): string => {
+    const field = SETTINGS_FIELDS[key];
+    if (apiValue === undefined) {
+      if ('defaultValue' in field && field.defaultValue !== undefined) {
+        if (field.type === 'providers') {
+          return JSON.stringify(field.defaultValue);
+        }
+        return String(field.defaultValue);
+      }
+      return '';
+    }
+    if (field.type === 'providers') {
+      return JSON.stringify(apiValue);
+    }
+    return String(apiValue);
+  },
+
+  getSettings: (db: { getSetting: (key: string) => string | null }): {
+    musicAssistantUrl: string;
+    musicAssistantToken?: string;
+    aiProviders: AIProviderConfig[];
+    customSystemPrompt?: string;
+    providerWeights: string;
+    defaultProviderId?: string;
+    defaultProvider: AIProviderConfig;
+    providers: AIProviderConfig[];
+    providerPreference: string[];
+  } => {
+    const settings: Record<string, unknown> = {};
+    for (const key of settingsUtils.getAllKeys()) {
+      const dbValue = db.getSetting(key);
+      const deserialisedValue = settingsUtils.deserialiseFromDB(key, dbValue);
+      settings[key] = deserialisedValue ?? settingsUtils.getDefaultValue(key);
+    }
+
+    const aiProviders = (settings.aiProviders as AIProviderConfig[] | undefined) ?? [];
+    const defaultProviderId = settings.defaultProviderId as string | undefined;
+
+    let defaultProvider: AIProviderConfig;
+    if (defaultProviderId !== undefined) {
+      const foundProvider = aiProviders.find(p => p.id === defaultProviderId);
+      defaultProvider = foundProvider ?? aiProviders[0] ?? {
+        id: 'default',
+        name: 'Default',
+        type: 'anthropic' as const,
+        apiKey: '',
+        model: 'claude-3-5-sonnet-20241022'
+      };
+    } else {
+      defaultProvider = aiProviders[0] ?? {
+        id: 'default',
+        name: 'Default',
+        type: 'anthropic' as const,
+        apiKey: '',
+        model: 'claude-3-5-sonnet-20241022'
+      };
+    }
+
+    const providerWeights = (settings.providerWeights as string | undefined) ?? '';
+    const providerPreference = providerWeights
+      .split(',')
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+
+    return {
+      musicAssistantUrl: (settings.musicAssistantUrl as string | undefined) ?? '',
+      musicAssistantToken: settings.musicAssistantToken as string | undefined,
+      aiProviders,
+      customSystemPrompt: settings.customSystemPrompt as string | undefined,
+      providerWeights,
+      defaultProviderId,
+      defaultProvider,
+      providers: aiProviders,
+      providerPreference
+    };
+  }
+};


### PR DESCRIPTION
This pull request implements support for Music Assistant 2.7+ authentication throughout the backend and updates the documentation and frontend settings UI accordingly. The main changes ensure that an authentication token is required and properly handled for all Music Assistant operations, fixing previous issues where only WebSocket connectivity was tested. The README now documents the authentication requirement and guides users on how to obtain and use the token.

**Backend authentication and API changes:**

* Updated `MusicAssistantClient` (`backend/src/services/musicAssistant.ts`) to support authentication by accepting a token in `connect()` and sending an `auth` command after connecting. [[1]](diffhunk://#diff-1ffcf46d55c1d982bebff861d08739db8f80101898ae0dea66be60e1a3bf5e34R7-R32) [[2]](diffhunk://#diff-1ffcf46d55c1d982bebff861d08739db8f80101898ae0dea66be60e1a3bf5e34R59-R69)
* Modified all usages of `MusicAssistantClient` and related helper functions to accept and pass the token parameter, ensuring all playlist generation, refinement, and creation operations authenticate with Music Assistant. [[1]](diffhunk://#diff-72bf4c8dc38e466d6af9bf8935d619e51a0cd01c9abfbab6a750fcadf1c284efL7-R10) [[2]](diffhunk://#diff-9bb699f83e58441fcad2dbadbb801fe0c28e504360979caffedda6a1eaa3c24dR16) [[3]](diffhunk://#diff-9bb699f83e58441fcad2dbadbb801fe0c28e504360979caffedda6a1eaa3c24dR32) [[4]](diffhunk://#diff-9bb699f83e58441fcad2dbadbb801fe0c28e504360979caffedda6a1eaa3c24dL45-R47) [[5]](diffhunk://#diff-9bb699f83e58441fcad2dbadbb801fe0c28e504360979caffedda6a1eaa3c24dL75-R77) [[6]](diffhunk://#diff-9bb699f83e58441fcad2dbadbb801fe0c28e504360979caffedda6a1eaa3c24dL104-R106) [[7]](diffhunk://#diff-07f9e6182856005b7450d1cc15a5b9aab54f1b90f3eaea0c50dea73ad971c7faR12-R17) [[8]](diffhunk://#diff-07f9e6182856005b7450d1cc15a5b9aab54f1b90f3eaea0c50dea73ad971c7faR78-R83) [[9]](diffhunk://#diff-7885b7aee9c6cab578ac6910b8d44e29d8722796b0e779f23d09926396cdae90R5-R9) [[10]](diffhunk://#diff-b67c5a1d9bafd5fda47bd0ea40ae80164f30d410167883bd448fd746ad0a6af6R58) [[11]](diffhunk://#diff-b67c5a1d9bafd5fda47bd0ea40ae80164f30d410167883bd448fd746ad0a6af6L160-R161) [[12]](diffhunk://#diff-b67c5a1d9bafd5fda47bd0ea40ae80164f30d410167883bd448fd746ad0a6af6R202) [[13]](diffhunk://#diff-b67c5a1d9bafd5fda47bd0ea40ae80164f30d410167883bd448fd746ad0a6af6L230-R232) [[14]](diffhunk://#diff-b67c5a1d9bafd5fda47bd0ea40ae80164f30d410167883bd448fd746ad0a6af6R274)
* Refactored types for Music Assistant client into a separate file for maintainability.

**API endpoint and test connection improvements:**

* Enhanced `/playlists/test-ma` endpoint to accept and test both `musicAssistantUrl` and `musicAssistantToken`, verifying actual authentication by calling a protected MA command.

**Frontend and documentation updates:**

* Added token input field and state management to the settings UI, allowing users to enter and save their Music Assistant token. [[1]](diffhunk://#diff-848c4346609b3cafb7ab2020abb6df678fc8f267df33406b116e020b104e7962R15-R16) [[2]](diffhunk://#diff-848c4346609b3cafb7ab2020abb6df678fc8f267df33406b116e020b104e7962R38-R39)
* Updated `README.md` to document the authentication requirement for MA 2.7+, including instructions for obtaining the token and configuring the app. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R123) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L296-R298) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R459) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L555-R566)
* Added a detailed implementation plan and issue notes for the authentication fix.