### PR TITLE
fix: add safe area insets for notched devices

### DIFF
--- a/frontend/src/components/MainView.tsx
+++ b/frontend/src/components/MainView.tsx
@@ -48,7 +48,7 @@ export const MainView: React.FC<IMainViewProps> = ({
     openRefine,
     closeRefine
 }) => (
-    <div className="min-h-screen bg-base-200">
+    <div className="min-h-screen bg-base-200 pb-[var(--safe-area-inset-bottom)]">
         <Navbar onShowSettings={openSettings} onShowHistory={openHistory} />
 
         {error !== null && <AlertMessage type="error" message={error} onDismiss={clearError} />}
@@ -56,7 +56,7 @@ export const MainView: React.FC<IMainViewProps> = ({
             <AlertMessage type="success" message={successMessage} onDismiss={clearSuccess} />
         )}
 
-        <div className="container mx-auto px-4 py-8">
+        <div className="container mx-auto px-4 py-8 pl-[max(1rem,var(--safe-area-inset-left))] pr-[max(1rem,var(--safe-area-inset-right))]">
             <div className="max-w-6xl mx-auto">
                 <PresetPrompts
                     presets={presets}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -6,7 +6,7 @@ interface INavbarProps {
 }
 
 export const Navbar: React.FC<INavbarProps> = ({ onShowHistory, onShowSettings }) => (
-    <div className="navbar bg-base-100 shadow-lg">
+    <div className="navbar bg-base-100 shadow-lg pt-[var(--safe-area-inset-top)] pl-[var(--safe-area-inset-left)] pr-[var(--safe-area-inset-right)]">
         <div className="container mx-auto px-2 sm:px-4 flex items-center max-w-6xl">
             <div className="flex-1 flex items-start gap-2 sm:gap-3 min-w-0">
                 <img src="/logo.png" alt="Logo" className="h-8 sm:h-12 flex-shrink-0" />

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -60,8 +60,8 @@ export const SettingsPage: React.FC<ISettingsPageProps> = ({
     };
 
     return (
-        <div className="min-h-screen bg-base-200 py-8">
-            <div className="container mx-auto px-4 max-w-2xl">
+        <div className="min-h-screen bg-base-200 py-8 pt-[max(2rem,var(--safe-area-inset-top))] pb-[max(2rem,var(--safe-area-inset-bottom))]">
+            <div className="container mx-auto px-4 max-w-2xl pl-[max(1rem,var(--safe-area-inset-left))] pr-[max(1rem,var(--safe-area-inset-right))]">
                 <div className="card bg-base-100 shadow-xl">
                     <div className="card-body">
                         <SettingsHeader />

--- a/frontend/src/components/VersionCopyrightFooter.tsx
+++ b/frontend/src/components/VersionCopyrightFooter.tsx
@@ -10,7 +10,7 @@ export const VersionCopyrightFooter: FC<IVersionCopyrightFooterProps> = ({
     showCopyright = false,
     showVersion = true
 }) => (
-    <footer className="absolute bottom-0 left-0 mt-6 text-center text-xs italic opacity-50">
+    <footer className="absolute bottom-0 left-0 mt-6 text-center text-xs italic opacity-50 pb-[var(--safe-area-inset-bottom)] pl-[var(--safe-area-inset-left)]">
         {showVersion && <>Version {version}</>}
         {showVersion && showCopyright && " | "}
         {showCopyright && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,2 +1,10 @@
 @import 'tailwindcss';
 @plugin 'daisyui';
+
+/* Safe area insets for notched devices (iPhone X+, etc.) */
+:root {
+    --safe-area-inset-top: env(safe-area-inset-top, 0px);
+    --safe-area-inset-right: env(safe-area-inset-right, 0px);
+    --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-area-inset-left: env(safe-area-inset-left, 0px);
+}


### PR DESCRIPTION
Add CSS custom properties for safe-area-insets and apply them to:
- Navbar (top, left, right padding)
- MainView (bottom padding, left/right content padding)
- SettingsPage (top, bottom, left, right padding)
- VersionCopyrightFooter (bottom, left padding)

This ensures the app displays correctly on devices with notches
like iPhone X+ by using env(safe-area-inset-*) CSS functions.

Fixes #18